### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/data/com.github.danrabbit.harvey.appdata.xml.in
+++ b/data/com.github.danrabbit.harvey.appdata.xml.in
@@ -99,7 +99,7 @@
   </content_rating>
     <translation type="gettext">com.github.danrabbit.harvey</translation>
     <developer id="com.github.danirabbit">
-      <name>Daniel Foré</name>
+      <name>Danielle Foré</name>
     </developer>
     <url type="homepage">https://github.com/danrabbit</url>
     <url type="bugtracker">https://github.com/danrabbit/harvey/issues</url>

--- a/data/com.github.danrabbit.harvey.appdata.xml.in
+++ b/data/com.github.danrabbit.harvey.appdata.xml.in
@@ -98,7 +98,9 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
     <translation type="gettext">com.github.danrabbit.harvey</translation>
-    <developer_name>Daniel Foré</developer_name>
+    <developer>
+      <name>Daniel Foré</name>
+    </developer>
     <url type="homepage">https://github.com/danrabbit</url>
     <url type="bugtracker">https://github.com/danrabbit/harvey/issues</url>
     <custom>

--- a/data/com.github.danrabbit.harvey.appdata.xml.in
+++ b/data/com.github.danrabbit.harvey.appdata.xml.in
@@ -98,7 +98,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
     <translation type="gettext">com.github.danrabbit.harvey</translation>
-    <developer>
+    <developer id="com.github.danirabbit">
       <name>Daniel Foré</name>
     </developer>
     <url type="homepage">https://github.com/danrabbit</url>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: com.github.danrabbit.harvey.desktop:103: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

I: com.github.danrabbit.harvey.desktop:~: desktop-app-launchable-omitted
   This `desktop-application` component has no `desktop-id` launchable tag, however it contains all
   the necessary information to display the application. The omission of the launchable entry means
   that this application can not be launched directly from installers or software centers. If this
   is intended, this information can be ignored, otherwise it is strongly recommended to add a
   launchable tag as well.

✔ Validation was successful: infos: 2, pedantic: 1
```