### PR TITLE
metainfo: Fix validate error and deprecation; shorten OARS

### DIFF
--- a/data/io.github.danirabbit.harvey.appdata.xml.in
+++ b/data/io.github.danirabbit.harvey.appdata.xml.in
@@ -2,8 +2,9 @@
 <!-- Copyright 2017-2024 Danielle Foré <danielle@elementary.io> -->
 <component type="desktop-application">
     <id>io.github.danirabbit.harvey</id>
+    <launchable type="desktop-id">io.github.danirabbit.harvey.desktop</launchable>
     <metadata_license>CC0-1.0</metadata_license>
-    <project_license>GPL-3.0+</project_license>
+    <project_license>GPL-3.0-or-later</project_license>
     <name>Harvey</name>
     <summary>The hero that Gotham needs right now</summary>
     <description>
@@ -68,35 +69,7 @@
             <image>https://raw.githubusercontent.com/danirabbit/harvey/main/data/screenshot.png</image>
         </screenshot>
     </screenshots>
-  <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
+    <content_rating type="oars-1.1" />
     <translation type="gettext">io.github.danirabbit.harvey</translation>
     <developer id="io.github.danirabbit">
       <name>Danielle Foré</name>


### PR DESCRIPTION
- Add `launchable` tag, which fixes the appstreamcli validation error:

```
[ryo@b760m ~/work/tmp/harvey (main =)]$ ninja -C builddir
ninja: Entering directory `builddir'
[1/1] Merging translations for data/io.github.danirabbit.harvey.appdata.xml
[ryo@b760m ~/work/tmp/harvey (main =)]$ appstreamcli validate builddir/data/io.github.danirabbit.harvey.appdata.xml
E: io.github.danirabbit.harvey:~: desktop-app-launchable-missing

✘ Validation failed: errors: 1, pedantic: 1
[ryo@b760m ~/work/tmp/harvey (main =)]$
```

- Replace [deprecated](https://spdx.org/licenses/GPL-3.0+.html) SPDX identifier `GPL-3.0+` with `GPL-3.0-or-later`
- Shorten OARS metadata